### PR TITLE
Set up Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.1
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - deps-{{ checksum "requirements/local.txt" }}
+          # fallback to using the latest cache if no exact match is found
+          - deps-
+
+      - run:
+          name: install dependencies
+          command: make venv
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: deps-{{ checksum "requirements/local.txt" }}
+
+      - run:
+          name: run unit tests
+          command: |
+            . venv/bin/activate
+            tox
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+
+      - run:
+          name: run doc tests
+          command: |
+            . venv/bin/activate
+            tox -e docs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # General.
-PYTHON_EXE = python3
 SHELL = /bin/bash
 TOPDIR = $(shell git rev-parse --show-toplevel)
 
@@ -86,7 +85,7 @@ setup: docker-network ## Setup the full environment (default)
 venv: venv/bin/activate ## Setup local venv
 
 venv/bin/activate: requirements/local.txt
-	test -d venv || virtualenv -p $(PYTHON_EXE) venv
+	test -d venv || python3 -m venv venv
 	. venv/bin/activate && pip install -U pip && pip install -r requirements/local.txt
 	. venv/bin/activate && python setup.py develop
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch configures Circle CI to run the unit tests and the docs
tests.

Drive-by:
* Use python3 venv module instead of `virtualenv`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CI is very important to ensure good code quality and limit the number of bugs introduced into the codebase.

## Types of changes
<!--- What types of changes does your code introduce? Remove what does not apply. -->
- infrastructure
